### PR TITLE
Add cstdint include to fix build error

### DIFF
--- a/include/cpu_compression_library.hpp
+++ b/include/cpu_compression_library.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 // CPU-SMASH LIBRARIES
 #include <cpu_options.hpp>

--- a/include/cpu_options.hpp
+++ b/include/cpu_options.hpp
@@ -9,6 +9,7 @@
 #pragma once
 
 #include <iostream>
+#include <cstdint>
 
 class CpuOptions {
  private:

--- a/include/cpu_smash.hpp
+++ b/include/cpu_smash.hpp
@@ -11,6 +11,7 @@
 #include <iostream>
 #include <string>
 #include <vector>
+#include <cstdint>
 
 // CPU-SMASH LIBRARIES
 #include <cpu_compression_library.hpp>


### PR DESCRIPTION
We are relying on one of the compression algorithms to include cstdint, and if it isn't enabled then we get a build error.